### PR TITLE
refactor: Move error handling in try-catch

### DIFF
--- a/client/src/components/DashProfile.tsx
+++ b/client/src/components/DashProfile.tsx
@@ -12,7 +12,6 @@ import {
 import app from "../utils/firebase";
 import { UserForm, UserResponse } from "../types/userType";
 import { userDestroy, userUpdate } from "../api/userApi";
-import axios, { AxiosError } from "axios";
 import {
   HiInformationCircle,
   HiOutlineExclamationCircle,
@@ -29,6 +28,7 @@ import {
 import { CircularProgressbar } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
 import { useNavigate } from "react-router-dom";
+import { handleDispatchError } from "../utils/error";
 
 const initialState: UserForm = {
   username: "",
@@ -122,13 +122,8 @@ const DashProfile: React.FC = () => {
         userUpdateSuccess({ message: "User updated successfully", user: res })
       );
       setImageFileUploadProgress(0);
-    } catch (err) {
-      const error = err as AxiosError | Error;
-      if (axios.isAxiosError(error)) {
-        dispatch(userUpdateFailure(error.response?.data.message));
-      } else {
-        dispatch(userUpdateFailure(error.message));
-      }
+    } catch (error) {
+      handleDispatchError(error, dispatch, userUpdateFailure);
     } finally {
       setFormData(initialState);
     }
@@ -145,15 +140,8 @@ const DashProfile: React.FC = () => {
         dispatch(userDestroySuccess());
         navigate("/");
       }
-    } catch (err) {
-      const error = err as AxiosError | Error;
-      if (axios.isAxiosError(error)) {
-        dispatch(userDestroyFailure(error.response?.data.message));
-      } else {
-        dispatch(
-          userDestroyFailure(error.message ?? "An unknown error occured")
-        );
-      }
+    } catch (error) {
+      handleDispatchError(error, dispatch, userDestroyFailure);
     }
   };
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -13,7 +13,6 @@ import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import ThemeProvider from "./components/ThemeProvider.tsx";
 import PrivateRoute from "./components/PrivateRoute.tsx";
-import { CookiesProvider } from "react-cookie";
 
 const router = createBrowserRouter([
   { path: "/", element: <HomePage /> },
@@ -31,11 +30,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <Provider store={store}>
       <PersistGate persistor={persistor}>
-        <CookiesProvider defaultSetOptions={{ path: "/" }}>
-          <ThemeProvider>
-            <RouterProvider router={router} />
-          </ThemeProvider>
-        </CookiesProvider>
+        <ThemeProvider>
+          <RouterProvider router={router} />
+        </ThemeProvider>
       </PersistGate>
     </Provider>
   </React.StrictMode>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -13,9 +13,9 @@ import {
 import { UserForm, UserResponse } from "../types/userType";
 import { RootState } from "../redux/store";
 import { loginStore } from "../api/authApi";
-import axios, { AxiosError } from "axios";
 import OAuth from "../components/OAuth";
 import { ErrMsg, IsLoading } from "../types/authType";
+import { handleDispatchError } from "../utils/error";
 
 const initialState: UserForm = {
   username: "",
@@ -51,14 +51,8 @@ const LoginPage: React.FC = function () {
       const res: UserResponse = await loginStore(formData);
       dispatch(loginSuccess(res));
       navigate("/");
-    } catch (err) {
-      const error = err as Error | AxiosError;
-
-      if (axios.isAxiosError(error)) {
-        dispatch(authFailure(error.response?.data.message));
-      } else {
-        dispatch(authFailure(error.message ?? "An unknown error occured"));
-      }
+    } catch (error) {
+      handleDispatchError(error, dispatch, authFailure);
     } finally {
       setFormData(initialState);
     }

--- a/client/src/pages/RegistrationPage.tsx
+++ b/client/src/pages/RegistrationPage.tsx
@@ -9,8 +9,8 @@ import { authReset, authFailure, authStart } from "../redux/slices/authSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../redux/store";
 import { registrationStore } from "../api/authApi";
-import axios, { AxiosError } from "axios";
 import OAuth from "../components/OAuth";
+import { handleDispatchError } from "../utils/error";
 
 const initialState: UserForm = {
   username: "",
@@ -46,14 +46,8 @@ const RegistrationPage: React.FC = function () {
       await registrationStore(formData);
       dispatch(authReset());
       navigate("/login");
-    } catch (err) {
-      const error = err as AxiosError | Error;
-
-      if (axios.isAxiosError(error)) {
-        dispatch(authFailure(error.response?.data.message));
-      } else {
-        dispatch(authFailure(error.message ?? "An unknown error occured"));
-      }
+    } catch (error) {
+      handleDispatchError(error, dispatch, authFailure);
     } finally {
       setFormData(initialState);
     }

--- a/client/src/utils/error.ts
+++ b/client/src/utils/error.ts
@@ -1,0 +1,20 @@
+import { PayloadAction } from "@reduxjs/toolkit";
+import axios, { AxiosError } from "axios";
+import { useDispatch } from "react-redux";
+
+type AppDispatch = ReturnType<typeof useDispatch>;
+
+const handleDispatchError = (
+  error: unknown,
+  dispatch: AppDispatch,
+  actionCreator: (payload: string) => PayloadAction<string>
+) => {
+  const err = error as Error | AxiosError;
+  if (axios.isAxiosError(err)) {
+    dispatch(actionCreator(err.response?.data.message));
+  } else {
+    dispatch(actionCreator(err.message ?? "An unknown error occured"));
+  }
+};
+
+export { handleDispatchError };


### PR DESCRIPTION
Extract error handling logic from the try-catch block into a separate file for better organization and reusability