### PR TITLE
fix(posts): Separate state management for formData and Quill editor

### DIFF
--- a/client/src/pages/PostCreatePage.tsx
+++ b/client/src/pages/PostCreatePage.tsx
@@ -44,6 +44,7 @@ const PostCreatePage: React.FC = () => {
   const [fileUrl, setFileUrl] = useState("");
   const [formData, setFormData] = useState(initialState);
   const [publishStatus, setPublishStatus] = useState(status);
+  const [quill, setQuill] = useState("");
   const navigate = useNavigate();
 
   const handleFileSelected: React.ChangeEventHandler<HTMLInputElement> = (
@@ -106,12 +107,19 @@ const PostCreatePage: React.FC = () => {
     setFormData({ ...formData, [e.target.id]: e.target.value });
   };
 
+  const handleChangeQuill = (event: string) => {
+    setQuill(event);
+  };
+
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
 
     try {
       setPublishStatus({ errorMsg: "", isLoading: true });
-      const newPost: PostData = await postCreate(formData);
+      const newPost: PostData = await postCreate({
+        ...formData,
+        content: quill,
+      });
       navigate(`/posts/${newPost.slug}`);
     } catch (error) {
       const err = error as AxiosError | Error;
@@ -207,9 +215,7 @@ const PostCreatePage: React.FC = () => {
           <ReactQuill
             theme="snow"
             readOnly={publishStatus.isLoading}
-            onChange={(value) => {
-              setFormData({ ...formData, content: value });
-            }}
+            onChange={handleChangeQuill}
             className="h-72"
           />
           <Button

--- a/client/src/pages/PostEditPage.tsx
+++ b/client/src/pages/PostEditPage.tsx
@@ -41,7 +41,6 @@ const PostEditPage: React.FC = () => {
   const [fileUploadProgress, setFileUploadProgress] = useState(0);
   const [fileUploading, setFileUploading] = useState(false);
   const [fileUploadError, setFileUploadError] = useState("");
-  // const [fileUrl, setFileUrl] = useState("");
   const [formData, setFormData] = useState(initialState);
   const [updateStatus, setUpdateStatus] = useState(status);
   const [quill, setQuill] = useState("");
@@ -96,11 +95,9 @@ const PostEditPage: React.FC = () => {
             );
             setFileUploadProgress(0);
             setFileUploading(false);
-            // setFileUrl("");
           },
           () => {
             getDownloadURL(uploadTask.snapshot.ref).then((downloadURL) => {
-              // setFileUrl(downloadURL);
               setFileUploadError("");
               setFileUploading(false);
               setFormData({ ...formData, imageUrl: downloadURL });


### PR DESCRIPTION
Distinguish state management between formData and Quill editor to address a bug triggered by distinct event handling mechanisms.